### PR TITLE
Update ParadoxAlarmSystemOTA.ino

### DIFF
--- a/ParadoxAlarmSystem/ParadoxAlarmSystemOTA/ParadoxAlarmSystemOTA.ino
+++ b/ParadoxAlarmSystem/ParadoxAlarmSystemOTA/ParadoxAlarmSystemOTA.ino
@@ -244,7 +244,14 @@ void updateArmStatus(byte event, byte sub_event){
          
          datachanged=true;
         break;
-
+            
+       case 14:
+         hassioStatus.stringArmStatus = "pending";
+         //homekitStatus.stringArmStatus = "PENDING";
+         homekitStatus.intArmStatus = 1;
+         
+         datachanged=true;
+        break;
       default : break;
     }
   }
@@ -303,7 +310,12 @@ void processMessage( byte event, byte sub_event, String dummy ){
       homekitStatus.sent = homekitStatus.intArmStatus;
       }
   }
-
+ 
+  if ((Hassio || HomeKit) && (event == 29))
+  {
+      sendArmStatus();
+      homekitStatus.sent = homekitStatus.intArmStatus;
+  }
  
   if ((Hassio ) && (event == 1 || event == 0))
   {

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ A command can be any of the following:
 
 ### Release Logs
 
+20200126: 
+1. Added ArmStatus: pending when exit delay 
+2. Added Event 29 (because of change pending status to arm_away after exit delay) 
+
 20190212:
 - Added retain message on hassio/Arm topic<br>
 - Added the ability to add credentials to mqtt.<br>


### PR DESCRIPTION
1. Added ArmStatus: pending when exit delay 
2. Added Event 29 (because of change pneding status to arm_away after exit delay) 

![pending](https://user-images.githubusercontent.com/55655876/73135857-967f4400-4047-11ea-87bc-ff0684dbcc8c.JPG)
